### PR TITLE
Use JOCL 2.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <clij2imagej1.version>2.5.1.4</clij2imagej1.version>
         <clupath.version>0.5.1.4</clupath.version>
 
-        <jocl.version>2.0.2</jocl.version>
+        <jocl.version>2.0.5</jocl.version>
         <bridj.version>0.7.0</bridj.version>
     </properties>
 


### PR DESCRIPTION
JOCL 2.0.5 has been the stable release for some time. Including this old release seems to clobber newer versions included with other plugins that use JOCL, due to the priority assigned by the ImageJ updater.

It might be worth considering updating the scijava version in this parent pom as it's quite old now.